### PR TITLE
buf fix: bedtools flank generates a promoter of a certain length (pro…

### DIFF
--- a/PMETdev/promoters_index_pair.sh
+++ b/PMETdev/promoters_index_pair.sh
@@ -173,10 +173,7 @@ fi
 print_fluorescent_yellow "     3. Extracting chromosome, start, end, gene ..."
 
 # 使用grep查找字符串 check if gene_id is present
-grep -q "$gff3id" $indexingOutputDir/genelines.gff3
-
-# 检查状态码 check presence
-if [ $? -eq 0 ]; then
+if grep -q "$gff3id" "$indexingOutputDir/genelines.gff3"; then
     python3 $pmetroot/parse_genelines.py $gff3id $indexingOutputDir/genelines.gff3 $bedfile
 else
     gff3id='ID='
@@ -232,7 +229,10 @@ bedtools flank \
     -l $promlength \
     -r 0 -s -i $bedfile \
     -g $indexingOutputDir/bedgenome.genome \
-    > $indexingOutputDir/promoters.bed
+    > $indexingOutputDir/promoters_not_sorted.bed
+# Sort by starting coordinate
+sortBed -i $indexingOutputDir/promoters_not_sorted.bed > $indexingOutputDir/promoters.bed
+rm -rf $indexingOutputDir/promoters_not_sorted.bed
 
 # -------------------------------------------------------------------------------------------
 print_fluorescent_yellow "     8.1 Remove promoters with less than 20 base pairs"

--- a/PMETdev/promoters_index_pair_new_fimo.sh
+++ b/PMETdev/promoters_index_pair_new_fimo.sh
@@ -220,10 +220,7 @@ fi
 print_light_blue "     3. Extracting chromosome, start, end, gene ..."
 
 # 使用grep查找字符串 check if gene_id is present
-grep -q "$gff3id" $indexingOutputDir/genelines.gff3
-
-# 检查状态码 check presence
-if [ $? -eq 0 ]; then
+if grep -q "$gff3id" "$indexingOutputDir/genelines.gff3"; then
     python3 $pmetroot/parse_genelines.py $gff3id $indexingOutputDir/genelines.gff3 $bedfile
 else
     gff3id='ID='
@@ -278,7 +275,10 @@ bedtools flank \
     -l $promlength \
     -r 0 -s -i $bedfile \
     -g $indexingOutputDir/bedgenome.genome \
-    > $indexingOutputDir/promoters.bed
+    > $indexingOutputDir/promoters_not_sorted.bed
+# Sort by starting coordinate
+sortBed -i $indexingOutputDir/promoters_not_sorted.bed > $indexingOutputDir/promoters.bed
+rm -rf $indexingOutputDir/promoters_not_sorted.bed
 
 # -------------------------------------------------------------------------------------------
 print_fluorescent_yellow "     8.1 Remove promoters with less than 20 base pairs"


### PR DESCRIPTION
buf fix: bedtools flank generates a promoter of a certain length (promoter.bed). The start coordinates of the promoter may not be arranged in order.